### PR TITLE
Credential registry authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -1671,7 +1671,7 @@ in a service object.
           Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g., for product passports on a product type level. An additional authentication for limiting access to certain credentials or partially disclosed credentials is optional.
         </p>
         <h4>Authenticated Request</h4>
-        <p>In order to perform an authenticated request, the credential registry endpoint MUST be called with a `POST` request. The request body MUST contain the `vp` property, holding the authenticating verifiable presentation. The `verifiableCredential` field of the presentation MAY be empty. In case the presentation contains credentials, they CAN be used to authenticate the requester beyond its DID. The `domain` field of the presentation MUST be the URL of the request. The `challenge` field of the presentation MUST be an empty string.</p>
+        <p>In order to perform an authenticated request, the credential registry endpoint MUST be called with a `POST` request. The request body MUST contain the `vp` property, holding the authenticating verifiable presentation. The `verifiableCredential` field of the presentation MAY be empty. If the presentation contains credentials, they MAY be used to authenticate the requester beyond its DID. The `domain` field of the presentation MUST be the URL of the request. The `challenge` field of the presentation MUST be an empty string.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -1668,8 +1668,10 @@ in a service object.
         <h4>CredentialRegistry</h4>
         <p>The <code>CredentialRegistry</code> endpoint allows publication of a dedicated service endpoint in a DID document, through which verifiable credentials can be queried. Each registry endpoint is a REST endpoint. When a `GET` request is sent to the URI formed by appending the <code>credentialSubject.id</code> as a URL-encoded string to the given endpoint URI, the registry MUST return an array of verifiable credentials associated with the subject ID. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
         <p class="note">
-          Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g., for product passports on a product type level. An additional authentication for limiting access to certain credentials is currently under development.
+          Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g., for product passports on a product type level. An additional authentication for limiting access to certain credentials or partially disclosed credentials is optional.
         </p>
+        <h4>Authenticated Request</h4>
+        <p>In order to perform an authenticated request, the credential registry endpoint MUST be called with a `POST` request. The request body MUST contain the `vp` property, holding the authenticating verifiable presentation. The `verifiableCredential` field of the presentation MAY be empty. In case the presentation contains credentials, they CAN be used to authenticate the requester beyond its DID. The `domain` field of the presentation MUST be the requested URL of the request. The `challenge` field of the presentation must be an empty string.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1722,6 +1724,35 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
   ...
 ]
         </pre>
+        <pre class="example" title="Example of an authenticated request">
+$ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -H 'accept: application/ld+json, application/json' \
+    -d '{
+        vp: {
+          "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://w3id.org/security/suites/ed25519-2020/v1"
+          ],
+          "type": [
+              "VerifiablePresentation"
+          ],
+          "verifiableCredential": [
+              ...
+          ],
+          "proof": {
+              "type": "Ed25519Signature2020",
+              "created": "2023-06-19T10:19:04Z",
+              "verificationMethod": "did:web:requester.domain.com#auth-key",
+              "proofPurpose": "authentication",
+              "challenge": "",
+              "domain": "https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1"
+              "proofValue": "z3BCT7...QoHiGWMn1V"
+          }
+      }
+    }'
+                  </pre>
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1671,7 +1671,7 @@ in a service object.
           Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g., for product passports on a product type level. An additional authentication for limiting access to certain credentials or partially disclosed credentials is optional.
         </p>
         <h4>Authenticated Request</h4>
-        <p>In order to perform an authenticated request, the credential registry endpoint MUST be called with a `POST` request. The request body MUST contain the `vp` property, holding the authenticating verifiable presentation. The `verifiableCredential` field of the presentation MAY be empty. In case the presentation contains credentials, they CAN be used to authenticate the requester beyond its DID. The `domain` field of the presentation MUST be the requested URL of the request. The `challenge` field of the presentation must be an empty string.</p>
+        <p>In order to perform an authenticated request, the credential registry endpoint MUST be called with a `POST` request. The request body MUST contain the `vp` property, holding the authenticating verifiable presentation. The `verifiableCredential` field of the presentation MAY be empty. In case the presentation contains credentials, they CAN be used to authenticate the requester beyond its DID. The `domain` field of the presentation MUST be the URL of the request. The `challenge` field of the presentation MUST be an empty string.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>


### PR DESCRIPTION
# First draft

Authenticated registry requests shall be performed doing a POST request carrying the authentication. As a first option we chose verifiable presentations (VPs) as the mean authentication. VPs already take over the authentication of the requesting identity by design and are a proven building block of the DID ecosystem. Further they can contain verifiable credentials which may be needed for authentication as well, e.g. [GS1LicenceCredentials](https://github.com/gs1/VC-Data-Model).

## Open questions

### Replay attacks

**Option 1**  
Obtain challenge for the VP via an additional endpoint `registry/{id}/challenge`

**Option 2**  
Add an expirationDate with a short delay to the VP (not intended (?) in the data model but possible with the LinkedDataSignature)

### Protocol options

Allow OpenID4VP from the registry side?
- Registry provides [presentation request](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5) for each route
- direct_post route is the route of the subject.id request which is then used to fetch the credentials in an authenticated way

-> Out of scope of OID4VC/little bit of misuse of the protocol
-> privacy issue: the necessary authentication requirements are partially revealed with the presentation request


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/european-epc-competence-center/did-spec-registries/pull/521.html" title="Last updated on Oct 27, 2023, 10:01 AM UTC (8c4ea8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/521/8f43dbd...european-epc-competence-center:8c4ea8b.html" title="Last updated on Oct 27, 2023, 10:01 AM UTC (8c4ea8b)">Diff</a>