### PR TITLE
Adding DID Method specification did:bsv

### DIFF
--- a/methods/bsv.json
+++ b/methods/bsv.json
@@ -1,0 +1,9 @@
+{
+  "name": "bsv",
+  "status": "registered",
+  "verifiableDataRegistry": "BSV",
+  "contactName": "Thomas Moretti",
+  "contactEmail": "t.moretti@nchain.com",
+  "contactWebsite": "https://www.nchain.com/",
+  "specification": "https://github.com/nchain-research/nChain-Identity-bsvdid-method"
+}


### PR DESCRIPTION
Adding new UTXO blockchain friendly specification, applied here to trustregistry "BSV", thus named did:bsv.

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [X] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [X] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [X] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [X] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [X] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [X] The JSON file contains a `contactEmail` address [OPTIONAL].
- [X] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].
