### PR TITLE
Add did:andorra method to DID Method Registry

### DIFF
--- a/methods/andorra.json
+++ b/methods/andorra.json
@@ -1,0 +1,9 @@
+{
+  "name": "andorra",
+  "status": "provisional",
+  "specification": "https://github.com/davidgbvargroup/did-andorra-method-spec/blob/main/spec.md",
+  "contactName": "David García Beatove",
+  "contactEmail": "david.garciab@vargroupiberia.com",
+  "contactWebsite": "https://www.vargroup.es/",
+  "verifiableDataRegistry": "Andorra National Registry (NRTAD)"
+}


### PR DESCRIPTION
This PR registers the `did:andorra` method in the W3C DID Method Registry.

- Specification: https://github.com/davidgbvargroup/did-andorra-method-spec/blob/main/spec.md
- Status: provisional
- Contact: David García Beatove (david.garcia@vargroupiberia.com)
- Verifiable Data Registry: Andorra National Registry (NRTAD)

----- DID METHOD REGISTRATION FORM: DELETE EVERYTHING ABOVE THIS LINE ------

### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
  Note: `did:andorra` only supports **Read (Resolve)**.
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].
