### PR TITLE
Register did:aria DID method

### DIFF
--- a/methods/did-aria.json
+++ b/methods/did-aria.json
@@ -1,0 +1,9 @@
+{
+  "name": "aria",
+  "status": "registered",
+  "verifiableDataRegistry": "DNS TXT + HTTPS endpoint",
+  "contactName": "TrustLayer Foundation A.C.",
+  "contactEmail": "info@trustlayer.foundation",
+  "contactWebsite": "https://aria.bar",
+  "specification": "https://aria.bar/spec#did-method"
+}


### PR DESCRIPTION
Register the `did:aria` DID method for verifiable AI agent identity.

- **Method name:** aria
- **Specification:** https://aria.bar/spec#did-method
- **Maintainer:** TrustLayer Foundation A.C.
- **Status:** Registered
- **Verifiable data registry:** DNS TXT + HTTPS endpoint
- **Resolution:**
  - L0 (Anchored): direct HTTPS fetch from `api.aria.bar/v1/aids/{did}` → signature verify against the registry's published key set
  - L1+ (Identified, Certified, Sovereign): DNS TXT lookup at `_aria.<domain>` returning a pointer (`v=ARIA1; id=<did>; h=sha256:<hash>; r=<url>`) → HTTPS fetch from the resolution URL → SHA-256 hash compare against the TXT record → composite signature verify
- **Cryptography:** ML-DSA-65 + Ed25519 composite (FIPS 204 + RFC 8032), suite `mldsa65-ed25519-2026`
- **Credential format:** W3C Verifiable Credential 2.0 (JSON-LD)
- **Revocation:** W3C Bitstring StatusList 2021
- **Implementation:** Live at https://api.aria.bar
- **SDK:** https://www.npmjs.com/package/@aria-registry/verify
- **License:** Apache 2.0 (code) + CC-BY-4.0 (specification)

The `did:aria` method provides DNS-anchored decentralized identity for AI agents operating across organizational boundaries. The trust model inherits 40 years of DNS governance — agents at L1 and above prove control of a domain via a published TXT record; the same hash that anchors the AID to the domain also pins the served document, so the AID cannot be silently substituted between DNS resolution and HTTPS retrieval. L0 credentials resolve via HTTPS only and serve as a zero-cost on-ramp without claiming domain control.

Filed with NIST PQC Implementation Registry as NIST-2025-0035 (March 2026).