### PR TITLE
Update did:xny specification link to v1.0.2

### DIFF
--- a/methods/xny.json
+++ b/methods/xny.json
@@ -5,5 +5,5 @@
   "contactName": "Xny Protocol",
   "contactEmail": "george@inductive.network",
   "contactWebsite": "https://xny.ai/",
-  "specification": "https://github.com/humanbased-ai/xny-did/blob/v1.0.1/docs/xny-did-method.md"
+  "specification": "https://github.com/humanbased-ai/xny-did/blob/v1.0.2/docs/xny-did-method.md"
 }


### PR DESCRIPTION
Updates the `specification` link for the already-registered `did:xny` method entry from the `v1.0.1` tag to `v1.0.2`. No other field changes, and no change to registration status.

### Why

After `v1.0.1` was tagged and registered, the specification gained a normative **Authoritative Deployment** section. `did:xny` identifiers deliberately carry no network segment — the method-specific id is derived from an off-chain user identifier and is byte-identical on every chain — so the same identifier can exist in more than one registry deployment. `v1.0.1` left the entire chain binding out of scope, which meant it did not say which document a resolver should return.

`v1.0.2` closes that: a deployment topology must designate exactly one authoritative deployment, resolvers must resolve against it only and must not fall back to a non-authoritative deployment, and test-network deployments must not be served through a publicly advertised resolver. Identifier syntax and derivation are unchanged.

Keeping the registry pointed at `v1.0.1` would leave readers arriving from this registry looking at the version that still has the ambiguity.

### Verification

- `methods/xny.json` remains valid JSON; the diff is a single line.
- `node tooling/validate-registry.js` → `✅ did method registry is valid`.
- The new link resolves: `https://github.com/humanbased-ai/xny-did/blob/v1.0.2/docs/xny-did-method.md` (HTTP 200). It points at an annotated, immutable tag rather than a branch.