### PR TITLE
Update did:solidus specification link to v0.2.0

### DIFF
--- a/methods/solidus.json
+++ b/methods/solidus.json
@@ -5,5 +5,5 @@
     "contactName": "Solidus Network",
     "contactEmail": "info@solidus.network",
     "contactWebsite": "https://solidus.network",
-    "specification": "https://github.com/solidusnetwork/did-solidus-spec/blob/v0.1.0/SPEC.md"
+    "specification": "https://github.com/solidusnetwork/did-solidus-spec/blob/v0.2.0/SPEC.md"
 }


### PR DESCRIPTION
Updates the `specification` URL for `did:solidus` from the `v0.1.0` tag to `v0.2.0`.

`v0.1.0` — the version this registry currently points at — contains errors in the identifier
grammar and in every one of its examples. They were found while checking our own documentation
against the chain and are corrected in `v0.2.0`:

- **The ABNF admitted characters the method cannot mint.** `base58char` was `ALPHA / DIGIT`, which
  includes `0`, `O`, `I` and `l`, with the exclusions noted only in a comment. A parser generated
  from that grammar accepts identifiers `did:solidus` can never produce. The alphabet is now
  enumerated as six explicit ranges.
- **All three example identifiers in §4.3 were unproducible by the derivation in §4.2.** One
  decoded to 23 bytes rather than the specified 20; the other two were not Base58 at all (both
  contained `0`).
- **The stated length range was impossible.** "Typically 27–33 characters for a 20-byte payload" —
  a 20-byte payload encodes to 20–28 characters. That upper bound is what allowed the invalid
  32-character examples to look acceptable. Over-28 is now a `MUST` reject, and the bound is in the
  grammar (`20*28base58char`).
- **The DID Document example was internally inconsistent** — its `publicKeyMultibase` did not derive
  to its own `id`, so the single worked example of §4.2 contradicted it. It now uses a verified pair,
  and the identifier resolves on the public testnet.

**No normative change to the method.** The identifier construction, DID Document shape and operation
semantics are unchanged, and every identifier valid under `v0.1.0` remains valid — this is a minor
revision under the spec's own versioning rule. `SPEC.md` carries a "Changes in version 0.2.0" section
for implementers who generated a parser from `v0.1.0`.

Registered via #713. Contact details in the entry are unchanged; only the `specification` field moves.