### PR TITLE
Add did:definitiveid method

### DIFF
--- a/methods/definitiveid.json
+++ b/methods/definitiveid.json
@@ -1,0 +1,9 @@
+{
+  "name": "definitiveid",
+  "status": "registered",
+  "specification": "https://github.com/davidgbvargroup/did-definitiveid-method-spec/blob/main/spec.md",
+  "contactName": "David Garcia Beatove",
+  "contactEmail": "david.garciab@vargroupiberia.com",
+  "contactWebsite": "https://www.vargroup.es/",
+  "verifiableDataRegistry": "DefinitiveID platform"
+}


### PR DESCRIPTION
### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].