### PR TITLE
did:oan Method Registration - Remove second email address in contactEmail as that breaks registry publishing

### DIFF
--- a/methods/oan.json
+++ b/methods/oan.json
@@ -3,7 +3,7 @@
   "status": "registered",
   "verifiableDataRegistry": "OpenAgenet root-governed registry and blockchain-backed authorization bulletin",
   "contactName": "OpenAgenet (OAN)",
-  "contactEmail": "xujinliang@caict.ac.cn; jlxufly@gmail.com",
+  "contactEmail": "xujinliang@caict.ac.cn",
   "contactWebsite": "https://github.com/OpenAgenet",
   "specification": "https://github.com/OpenAgenet/oan-public-docs/blob/main/did-oan-specs/doc/OAN%20DID%20Method%20Specification.md"
 }


### PR DESCRIPTION
Removes email address jlxufly@gmail.com from contactEmail field in registration of did:oan because the inclusion of two email addresses breaks the CI/CD publishing of the registry.
