### PR TITLE
Register did:cha2a method

### DIFF
--- a/methods/cha2a.json
+++ b/methods/cha2a.json
@@ -1,0 +1,8 @@
+{
+  "name": "cha2a",
+  "status": "registered",
+  "verifiableDataRegistry": "cha2a Registry (registry-mediated identity for agents, skills, publishers and authorities; reference registry hosted at compliancehub.cn)",
+  "contactName": "wwumit",
+  "contactWebsite": "https://github.com/wwumit/did-method-cha2a",
+  "specification": "https://github.com/wwumit/did-method-cha2a/blob/main/did-method-cha2a.md"
+}

--- a/methods/cha2a.json
+++ b/methods/cha2a.json
@@ -4,6 +4,6 @@
   "verifiableDataRegistry": "cha2a Registry — https://compliancehub.cn",
   "contactName": "Wei Wu",
   "contactWebsite": "https://github.com/wwumit/did-method-cha2a",
-  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.0/did-method-cha2a.md",
+  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.0.2/did-method-cha2a.md",
   "contactEmail": "wuwei1st@gmail.com"
 }

--- a/methods/cha2a.json
+++ b/methods/cha2a.json
@@ -4,5 +4,6 @@
   "verifiableDataRegistry": "cha2a Registry (registry-mediated identity for agents, skills, publishers and authorities; reference registry hosted at compliancehub.cn)",
   "contactName": "wwumit",
   "contactWebsite": "https://github.com/wwumit/did-method-cha2a",
-  "specification": "https://github.com/wwumit/did-method-cha2a/blob/main/did-method-cha2a.md"
+  "specification": "https://github.com/wwumit/did-method-cha2a/blob/main/did-method-cha2a.md",
+  "contactEmail": "wuwei1st@gmail.com"
 }

--- a/methods/cha2a.json
+++ b/methods/cha2a.json
@@ -4,6 +4,6 @@
   "verifiableDataRegistry": "cha2a Registry — https://compliancehub.cn",
   "contactName": "Wei Wu",
   "contactWebsite": "https://github.com/wwumit/did-method-cha2a",
-  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.0.1/did-method-cha2a.md",
+  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.0/did-method-cha2a.md",
   "contactEmail": "wuwei1st@gmail.com"
 }

--- a/methods/cha2a.json
+++ b/methods/cha2a.json
@@ -1,9 +1,9 @@
 {
   "name": "cha2a",
   "status": "registered",
-  "verifiableDataRegistry": "cha2a Registry (registry-mediated identity for agents, skills, publishers and authorities; reference registry hosted at compliancehub.cn)",
-  "contactName": "wwumit",
+  "verifiableDataRegistry": "cha2a Registry — https://compliancehub.cn",
+  "contactName": "Wei Wu",
   "contactWebsite": "https://github.com/wwumit/did-method-cha2a",
-  "specification": "https://github.com/wwumit/did-method-cha2a/blob/main/did-method-cha2a.md",
+  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.0/did-method-cha2a.md",
   "contactEmail": "wuwei1st@gmail.com"
 }

--- a/methods/cha2a.json
+++ b/methods/cha2a.json
@@ -4,6 +4,6 @@
   "verifiableDataRegistry": "cha2a Registry — https://compliancehub.cn",
   "contactName": "Wei Wu",
   "contactWebsite": "https://github.com/wwumit/did-method-cha2a",
-  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.0/did-method-cha2a.md",
+  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.0.1/did-method-cha2a.md",
   "contactEmail": "wuwei1st@gmail.com"
 }

--- a/methods/cha2a.json
+++ b/methods/cha2a.json
@@ -4,6 +4,6 @@
   "verifiableDataRegistry": "cha2a Registry — https://compliancehub.cn",
   "contactName": "Wei Wu",
   "contactWebsite": "https://github.com/wwumit/did-method-cha2a",
-  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.0.2/did-method-cha2a.md",
+  "specification": "https://github.com/wwumit/did-method-cha2a/blob/v1.1.0/did-method-cha2a.md",
   "contactEmail": "wuwei1st@gmail.com"
 }


### PR DESCRIPTION
This PR registers `did:cha2a`, a registry-mediated DID method for agent identity and software source attestation.

Specification: https://github.com/wwumit/did-method-cha2a/blob/v1.1.0/did-method-cha2a.md

A `did:cha2a` identifier identifies a DID subject: a resource registered in a cha2a Registry, named by the `resource-type` and `resource-id` slots of the identifier (§3.1). Behaviour is specified for the resource types the method is built around — `agent` (mutual authentication, delegation and audit: §4.5, §6.5), `skill` and `package` (content integrity and provenance: §3.2, §4.7), and `verifier` (the independent checkers that every evidence record references: §4.6) — together with `registry`, `publisher`, and `org` (§3.2, §3.3). The type registry is deliberately open: implementations MUST NOT reject a DID solely because its `resource-type` is not yet registered (§3.2).

Resolution returns a W3C DID document whose verification method is the Registry's Ed25519 signing key, and whose services expose trust lookup, signed trust proofs, revocation, and content-integrity verification. The specification states the trust model plainly: a relying party trusts a `did:cha2a` DID exactly as much as it trusts the DID resolver it is configured with.

The specification is self-contained and covers method syntax (§2, §3.1 ABNF), all four DID operations — Create (§4.1), Read/Resolve (§4.2), Update (§4.3), Deactivate (§4.4) — DID document structure with verification relationships and a discovery document (§5, §5.1, §5.2), Security Considerations (§6, eleven subsections), and Privacy Considerations (§7, five subsections). §9 states the conformance surface and the test vectors that demonstrate it.

Limitations, stated in the specification itself (§9.4) rather than left implicit: (1) the L4 certification level requires at least two *independent* verifiers operating on live data and is not provable by fixtures alone; (2) federation between two real registries is not exercised — no second deployment exists; (3) the runtime-attestation vocabulary (§4.8) is reserved terminology, with no runtime behavior defined. The conformance fixtures and both reference verifiers are self-published by the maintainer, so they demonstrate that the specification is implementable and internally consistent, not that it has been independently validated by third parties.

Reference implementation (running, Apache-2.0), including the verifiable data registry at https://compliancehub.cn — discovery at `/.well-known/cha2a`, resolution at `/api/v1/did/<did>`.
Conformance suite (fixtures, reference verifiers, `MANIFEST.sha256`): https://github.com/wwumit/cha2a-conformance
Specification repository: https://github.com/wwumit/did-method-cha2a

Specification version: v1.1.0. License: Apache-2.0. Editor: wwumit.
