### PR TITLE
Update did:ma url to version 1.0.0 final

### DIFF
--- a/methods/ma.json
+++ b/methods/ma.json
@@ -1,7 +1,7 @@
 {
   "name": "ma",
   "status": "registered",
-  "specification": "https://github.com/bahner/ma-spec/blob/v1.0.0.rc.1/did-ma-spec-v1.md",
+  "specification": "https://github.com/bahner/ma-spec/blob/v1.0.0/did-ma-spec-v1.md",
   "contactName": "Lars Bahner",
   "contactEmail": "lars.bahner@gmail.com",
   "contactWebsite": "https://lars.bahner.com/",


### PR DESCRIPTION
This pull request is just to update the method with a proper version tag for v1.0.0 instead of an rc1 tag.

Since the rc1 the updatedAt field has been changed from timestamps with subsecond granularity to seconds.
It makes no sense to update at DID Document more often than that since propagating won't even have time to happen.

Just a final ounce of complexity squeezed from the method. This makes version 1 final