### PR TITLE
Fix case-mismatched links to DID Resolution error definitions

### DIFF
--- a/resolution/index.html
+++ b/resolution/index.html
@@ -537,7 +537,7 @@ These properties contain information pertaining to the DID resolution response.
           <tbody>
           <tr>
             <td>
-              <a href="https://w3c.github.io/did-resolution/#methodnotsupported">DID Resolution</a>
+              <a href="https://w3c.github.io/did-resolution/#METHOD_NOT_SUPPORTED">DID Resolution</a>
             </td>
           </tr>
           </tbody>
@@ -561,7 +561,7 @@ These properties contain information pertaining to the DID resolution response.
           <tbody>
           <tr>
             <td>
-              <a href="https://w3c.github.io/did-resolution/#internalerror">DID Resolution</a>
+              <a href="https://w3c.github.io/did-resolution/#INTERNAL_ERROR">DID Resolution</a>
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
Two links in the error registry point at lowercased fragments that do not exist. DID Resolution's error definitions carry `id="METHOD_NOT_SUPPORTED"` and `id="INTERNAL_ERROR"`, and fragment matching is case-sensitive, so both links currently go the top of the document rather than at the definition.

    #methodnotsupported  ->  #METHOD_NOT_SUPPORTED
    #internalerror       ->  #INTERNAL_ERROR

Four other links in the same registry are also broken, but those need a decision rather than a correction,so I'll open an issue for them.