### PR TITLE
Register did:julia

### DIFF
--- a/methods/julia.json
+++ b/methods/julia.json
@@ -1,0 +1,9 @@
+{
+  "name": "julia",
+  "status": "registered",
+  "verifiableDataRegistry": "Chia blockchain (singleton coins)",
+  "contactName": "Ken Griggs",
+  "contactEmail": "ken@julia.social",
+  "contactWebsite": "https://not.bot",
+  "specification": "https://github.com/julia-social/did-julia/blob/v1.0.0/spec/did-julia.md"
+}


### PR DESCRIPTION
This PR registers `did:julia`, a DID method rooted in Chia blockchain singletons.

Specification: https://github.com/julia-social/did-julia/blob/v1.0.0/spec/did-julia.md

A `did:julia` identifier is the base58 encoding of a Chia singleton launcher ID. The launcher ID commits to the DID's original BLS12-381 authentication key, so a DID's full key history is verifiable from genesis and signatures stay verifiable across key rotation. Current DID state — authentication configuration, custodians, recovery configuration, and credential revocation — is read from the chain by any Chia node, with no issuer or provider on the verification path.

The specification is self-contained and covers method syntax (§5), CRUD operations (§7), DID Documents (§8), the Verifiable Credentials 2.0 mapping (§9), Security Considerations (§10), and Privacy Considerations (§11).

One capability is specified and not yet implemented, and is flagged as such in the specification (§7.2, §12): the publication path that writes DID Document contents to Chia DataLayer and resolves them for readers. The DID singleton's document-pointer mechanism is shipped, and a `did:julia` DID is usable without a DID Document lookup, as the only required element of a DID Document is the DID value itself.

On-chain reference implementation (Chialisp, Apache 2.0): https://github.com/julia-social/julia_did_chialisp
Reference resolver (Python, Apache 2.0, in the specification repository): https://github.com/julia-social/did-julia