### PR TITLE
Register did:educreds method

### DIFF
--- a/methods/educreds.json
+++ b/methods/educreds.json
@@ -1,0 +1,9 @@
+{
+  "name": "educreds",
+  "status": "registered",
+  "verifiableDataRegistry": "EduCreds Protocol (IPFS + EVM-compatible chain)",
+  "contactName": "EduCreds Labs Co. Ltd",
+  "contactEmail": "partnerships@educreds.xyz",
+  "contactWebsite": "https://educreds.xyz",
+  "specification": "https://did.educreds.xyz"
+}


### PR DESCRIPTION
## Register `did:educreds` DID Method

### Summary
This PR registers the `did:educreds` DID method with the W3C DID Extensions registry.

### Method Details

| Field | Value |
|---|---|
| **Method name** | `educreds` |
| **Status** | registered |
| **Contact** | EduCreds Labs Co. Ltd |
| **Email** | partnerships@educreds.xyz |
| **Website** | https://educreds.xyz |
| **Specification** | https://did.educreds.xyz |

### About the Method

`did:educreds` is a DID method designed for academic credential infrastructure in Africa and emerging markets. It supports three subject types:

- **Institutions** (`did:educreds:institution:<uuid>`) — accredited universities and colleges
- **Students** (`did:educreds:student:<eth-address>`) — credential holders
- **Credentials** (`did:educreds:credential:<uuid>`) — individual verifiable credentials

### Specification Conformance

The specification at https://did.educreds.xyz covers all required sections per the W3C DID Core v1.1 specification:

- ✅ Method name and ABNF syntax
- ✅ Full CRUD operations (Create, Read/Resolve, Update, Deactivate)
- ✅ DID Document structure with verification methods and service endpoints
- ✅ Security Considerations (6 subsections)
- ✅ Privacy Considerations (4 subsections)
- ✅ Conformance statement
- ✅ Implementation status
- ✅ References

### Implementation

The method is implemented and operational. A live resolver is available at:
`GET https://api-dev.educreds.xyz/api/v1/did/resolve/:did`

Credentials issued under this method are stored on IPFS and anchored on an EVM-compatible chain for tamper-proof verification.
