### PR TITLE
Update did:aip registration to v2 (Solana to ERC-8004)

### DIFF
--- a/methods/aip.json
+++ b/methods/aip.json
@@ -1,9 +1,9 @@
 {
   "name": "aip",
   "status": "registered",
-  "verifiableDataRegistry": "Solana",
-  "contactName": "AIP Working Group",
+  "verifiableDataRegistry": "ERC-8004 Identity Registries on EVM chains",
+  "contactName": "Wiener Labs",
   "contactEmail": "emptylabs0@gmail.com",
-  "contactWebsite": "https://github.com/dr-wilson-empty/aip-beta",
-  "specification": "https://github.com/dr-wilson-empty/aip-beta/blob/main/standards/did-aip-method-spec.md"
+  "contactWebsite": "https://github.com/wienerlabs/square",
+  "specification": "https://github.com/wienerlabs/square/blob/main/docs/did-aip/method-spec-v2.md"
 }


### PR DESCRIPTION
### DID Method Registration

`did:aip` is already registered (#704, merged 2026-05-31). This updates the existing entry rather than adding a new method: the method moved from Solana to ERC-8004, so `verifiableDataRegistry` and `specification` both point somewhere different. A merged pull request cannot be amended, hence a new one.

**This is a substrate change, not an editorial clarification.** Version 1 anchored an agent identity to a Solana program-derived address. Version 2 reads an [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) Identity Registry, and the identifier carries the chain and the registry it came from:

```
did:aip:eip155:5042002:0x8004a818bfb912233c491871b3d84c89a494bd9e:892271
        └ CAIP-2 namespace and chain id  └ registry contract  └ ERC-721 tokenId
```

The method is consequently no longer tied to one ledger.

| field | from | to |
|---|---|---|
| `verifiableDataRegistry` | `Solana` | `ERC-8004 Identity Registries on EVM chains` |
| `specification` | the v1 document in `aip-beta` | [`method-spec-v2.md`](https://github.com/wienerlabs/square/blob/main/docs/did-aip/method-spec-v2.md) |
| `contactName` | `AIP Working Group` | `Wiener Labs` |
| `contactWebsite` | `dr-wilson-empty/aip-beta` | `wienerlabs/square` |

`name`, `status` and `contactEmail` are unchanged.

**The v1 specification stays published at its current URL.** §9.2 of the v2 specification requires a resolver to recognise a v1 identifier as well-formed and answer `unsupportedVersion` rather than reporting it as malformed, so an implementer supporting v1 has to be able to read what they are implementing.

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax). — §3.2, in ABNF
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations). — §7, one subsection each
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements). — §10, five subsections
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements). — §11
- [x] The JSON file I am submitting has passed all automated validation tests below. — `tooling/validate-registry.js` also run locally
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].

### Implementation

The specification's test vectors (Appendix A) are resolvable on Arc Testnet today, and the two agents below are registered permanently for exactly that purpose. The second has no agent URI at all, which ERC-8004 permits and which §5 treats as valid rather than as an error — it is the case where a DID Document has to be correct with nothing off-chain to build it from.

| | |
|---|---|
| `…:892271` | agent card embedded as a `data:` URI |
| `…:892272` | no agent URI |

A resolver ([`@squaresdk/did-resolver`](https://github.com/wienerlabs/square/tree/main/packages/did-resolver)) and a Universal Resolver driver ([`packages/did-aip-driver`](https://github.com/wienerlabs/square/tree/main/packages/did-aip-driver)) are implemented and open source under Apache-2.0. The corresponding Universal Resolver entry is [decentralized-identity/universal-resolver#561](https://github.com/decentralized-identity/universal-resolver/pull/561).

Contact: @dr-wilson-empty
