### PR TITLE
Add contact email and website for did:meta

### DIFF
--- a/methods/meta.json
+++ b/methods/meta.json
@@ -3,7 +3,7 @@
   "status": "registered",
   "verifiableDataRegistry": "Metadium",
   "contactName": "Metadium Foundation",
-  "contactEmail": "",
-  "contactWebsite": "",
+  "contactEmail": "jsong@cplabs.io",
+  "contactWebsite": "https://metadium.com",
   "specification": "https://github.com/METADIUM/meta-DID/blob/master/doc/DID-method-metadium.md"
 }


### PR DESCRIPTION
Fills in the two empty contact fields for the `meta` DID method.

```diff
-  "contactEmail": "",
-  "contactWebsite": "",
+  "contactEmail": "jsong@cplabs.io",
+  "contactWebsite": "https://metadium.com",
```

I am the CTO of CPLABS Inc., the company that maintains the `meta` method and its resolver, so this is the current maintainer contact.

The `specification` link was checked and still resolves. No other fields changed.
